### PR TITLE
Bring you own drinks and food

### DIFF
--- a/sponsorships/index.html
+++ b/sponsorships/index.html
@@ -35,9 +35,11 @@ title: Sponsorships
 
   <h2>Drinks sponsor - € 500</h2>
   <p>
-    There are two options;
-    either you buy (not only alcoholic) drinks fitting the amount of attendees for the event, in close communication with the organisers,
-    or you sponsor amsrb financially and we take care of it.
+    There are two options:
+    <ul>
+      <li>The sponsor takes care of the drinks fitting the amount of attendees, in close communication with the organisers,</li>
+      <li>The sponsor receives an invoice from amsrb.org for the amount of € 500 and we will take care of the drinks.</li>
+    </ul>
   </p>
   <p>Drinks sponsoring to the tune of € 500 (excluding VAT). You’ll receive an invoice for this exact amount.</p>
 
@@ -52,9 +54,11 @@ title: Sponsorships
 
   <h2>Food sponsor - € 500</h2>
   <p>
-    There are two options;
-    either you buy enough snacks and food for the amount of attendees for the event, in close communication with the organisers,
-    or you sponsor amsrb financially and we take care of it.
+    There are two options:
+    <ul>
+      <li>The sponsor takes care of the food fitting the amount of attendees, in close communication with the organisers,</li>
+      <li>The sponsor receives an invoice from amsrb.org for the amount of € 500 and we will take care of the food.</li>
+    </ul>
   </p>
   <p>Food sponsoring sets you back € 500 (excluding VAT). You’ll receive an invoice for this exact amount.</p>
 
@@ -69,9 +73,11 @@ title: Sponsorships
 
   <h2>Drinks & food sponsor - € 900</h2>
   <p>
-    There are two options;
-    either you buy (not only alcoholic) drinks, snacks and food fitting the amount of attendees for the event, in close communication with the organisers,
-    or you sponsor amsrb financially and we take care of it.
+    There are two options:
+    <ul>
+      <li>The sponsor takes care of the food and drinks   fitting the amount of attendees, in close communication with the organisers,</li>
+      <li>The sponsor receives an invoice from amsrb.org for the amount of € 500 and we will take care of the food and drinks  .</li>
+    </ul>
   </p>
 
   <p>A sponsorship covered both the Drinks and Food sponsorships. This sponsoring sets you back € 900 (excluding VAT). You’ll receive an invoice for this exact amount.</p>

--- a/sponsorships/index.html
+++ b/sponsorships/index.html
@@ -34,8 +34,12 @@ title: Sponsorships
   </ul>
 
   <h2>Drinks sponsor - € 500</h2>
-
-  <p>Drinks sponsoring to the tune of € 500 (excluding VAT). You’ll receive an invoice for this exact amount, budget that’s unused will add to our savings for a rainy day.</p>
+  <p>
+    There are two options;
+    either you buy (not only alcoholic) drinks fitting the amount of attendees for the event, in close communication with the organisers,
+    or you sponsor amsrb financially and we take care of it.
+  </p>
+  <p>Drinks sponsoring to the tune of € 500 (excluding VAT). You’ll receive an invoice for this exact amount.</p>
 
   <p>In return you'll receive:</p>
 
@@ -47,8 +51,12 @@ title: Sponsorships
   </ul>
 
   <h2>Food sponsor - € 500</h2>
-
-  <p>Food sponsoring sets you back € 500 (excluding VAT). You’ll receive an invoice for this exact amount, budget that’s unused will add to our savings for a rainy day.</p>
+  <p>
+    There are two options;
+    either you buy enough snacks and food for the amount of attendees for the event, in close communication with the organisers,
+    or you sponsor amsrb financially and we take care of it.
+  </p>
+  <p>Food sponsoring sets you back € 500 (excluding VAT). You’ll receive an invoice for this exact amount.</p>
 
   <p>In return you'll receive:</p>
 
@@ -60,8 +68,13 @@ title: Sponsorships
   </ul>
 
   <h2>Drinks & food sponsor - € 900</h2>
+  <p>
+    There are two options;
+    either you buy (not only alcoholic) drinks, snacks and food fitting the amount of attendees for the event, in close communication with the organisers,
+    or you sponsor amsrb financially and we take care of it.
+  </p>
 
-  <p>A sponsorship covered both the Drinks and Food sponsorships. This sponsoring sets you back € 900 (excluding VAT). You’ll receive an invoice for this exact amount, budget that’s unused will add to our savings for a rainy day.</p>
+  <p>A sponsorship covered both the Drinks and Food sponsorships. This sponsoring sets you back € 900 (excluding VAT). You’ll receive an invoice for this exact amount.</p>
 
   <p>In return you'll receive:</p>
 


### PR DESCRIPTION
Highlight that buying by the sponsor is an option.

Boyscout: Remove the notice that we may save some of the monies,
since it's no-one's business anyway.